### PR TITLE
Update README-classification-tutorial.md

### DIFF
--- a/docs/source/en/models/classification/README-classification-tutorial.md
+++ b/docs/source/en/models/classification/README-classification-tutorial.md
@@ -51,6 +51,7 @@ If we want to finetune the ImageNet model with `1000` classes on another classif
    * Pass this argument `--model.classification.finetune-pretrained-model` to enable finetuning
    * Specify number of classes in pre-trained model using `--model.classification.n-pretrained-classes` argument
    * Specify the location of pre-trained weights using `--model.classification.pretrained` argument
+   * Pass this argument `--model.resume-exclude-scopes classifier`
 
 For a concrete example, see training recipe of [MobileViTv2](README-mobilevit-v2.md)
 


### PR DESCRIPTION
When you want fine-tuning model on a custom dataset with another N of classes you have to pass argument `--model.resume-exclude-scopes classifier` otherwise, we will get an error about the mismatch classifier layer.